### PR TITLE
Fix Money.zero for payment domain

### DIFF
--- a/src/main/java/br/edu/ddd/project/paymentprocessing/domain/model/valueobjects/Money.java
+++ b/src/main/java/br/edu/ddd/project/paymentprocessing/domain/model/valueobjects/Money.java
@@ -8,8 +8,8 @@ public record Money(BigDecimal amount, Currency currency) {
     public Money {
         Objects.requireNonNull(amount, "Amount cannot be null");
         Objects.requireNonNull(currency, "Currency cannot be null");
-        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new IllegalArgumentException("Payment amount must be positive");
+        if (amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Payment amount cannot be negative");
         }
     }
 

--- a/src/test/java/br/edu/ddd/project/paymentprocessing/domain/model/valueobjects/MoneyTest.java
+++ b/src/test/java/br/edu/ddd/project/paymentprocessing/domain/model/valueobjects/MoneyTest.java
@@ -1,0 +1,18 @@
+package br.edu.ddd.project.paymentprocessing.domain.model.valueobjects;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MoneyTest {
+    @Test
+    void zeroShouldReturnValidInstance() {
+        Currency currency = Currency.getInstance("USD");
+        Money zero = assertDoesNotThrow(() -> Money.zero(currency));
+        assertEquals(0, zero.amount().compareTo(BigDecimal.ZERO));
+        assertEquals(currency, zero.currency());
+    }
+}


### PR DESCRIPTION
## Summary
- allow zero amounts in payment processing Money value object
- add unit test for `Money.zero`

## Testing
- `./mvnw -q test` *(fails: unable to download maven)*

------
https://chatgpt.com/codex/tasks/task_e_68438a3f2090832aa3ec543893c9f0a5