### PR TITLE
Add unit tests with Mockito support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 4. Como Usar
 Para desenvolvimento local:
-bash
+```bash
 # Use o perfil padrão (application.properties)
 mvn spring-boot:run
+```
 Para Docker:
-bash
+```bash
 # 1. Build dos JARs
 mvn clean package -DskipTests
-
+```
+```bash
 # 2. Subir tudo com Docker Compose
 docker-compose up -d
-
+```
+```bash
 # 3. Verificar logs
 docker-compose logs -f user-service
+```

--- a/src/main/java/br/edu/ddd/project/paymentprocessing/domain/model/valueobjects/Money.java
+++ b/src/main/java/br/edu/ddd/project/paymentprocessing/domain/model/valueobjects/Money.java
@@ -8,7 +8,7 @@ public record Money(BigDecimal amount, Currency currency) {
     public Money {
         Objects.requireNonNull(amount, "Amount cannot be null");
         Objects.requireNonNull(currency, "Currency cannot be null");
-        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+        if (amount.compareTo(BigDecimal.ZERO) < 0) {
             throw new IllegalArgumentException("Payment amount must be positive");
         }
     }

--- a/src/main/java/br/edu/ddd/project/usermanagement/application/exception/UserAlreadyExistsException.java
+++ b/src/main/java/br/edu/ddd/project/usermanagement/application/exception/UserAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package br.edu.ddd.project.usermanagement.application.exception;
+
+public class UserAlreadyExistsException extends RuntimeException {
+    public UserAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/edu/ddd/project/usermanagement/application/service/DomainEventPublisher.java
+++ b/src/main/java/br/edu/ddd/project/usermanagement/application/service/DomainEventPublisher.java
@@ -1,0 +1,5 @@
+package br.edu.ddd.project.usermanagement.application.service;
+
+public interface DomainEventPublisher {
+    void publish(Object event);
+}

--- a/src/main/java/br/edu/ddd/project/usermanagement/application/usecase/UserCreatedEvent.java
+++ b/src/main/java/br/edu/ddd/project/usermanagement/application/usecase/UserCreatedEvent.java
@@ -1,0 +1,5 @@
+package br.edu.ddd.project.usermanagement.application.usecase;
+
+import java.util.UUID;
+
+public record UserCreatedEvent(UUID userId, String email, String firstName, String lastName) {}

--- a/src/test/java/br/edu/ddd/project/ordermanagement/domain/model/entities/OrderItemTest.java
+++ b/src/test/java/br/edu/ddd/project/ordermanagement/domain/model/entities/OrderItemTest.java
@@ -1,0 +1,20 @@
+package br.edu.ddd.project.ordermanagement.domain.model.entities;
+
+import br.edu.ddd.project.ordermanagement.domain.model.valueobject.Money;
+import br.edu.ddd.project.ordermanagement.domain.model.valueobject.ProductId;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OrderItemTest {
+    @Test
+    void createCalculatesTotalPrice() {
+        Money unitPrice = Money.of(BigDecimal.TEN, Currency.getInstance("USD"));
+        OrderItem item = OrderItem.create(new ProductId(UUID.randomUUID()), "Item", 2, unitPrice);
+        assertEquals(unitPrice.multiply(2), item.getTotalPrice());
+    }
+}

--- a/src/test/java/br/edu/ddd/project/paymentprocessing/domain/model/MoneyTest.java
+++ b/src/test/java/br/edu/ddd/project/paymentprocessing/domain/model/MoneyTest.java
@@ -1,0 +1,16 @@
+package br.edu.ddd.project.paymentprocessing.domain.model;
+
+import br.edu.ddd.project.paymentprocessing.domain.model.valueobjects.Money;
+import org.junit.jupiter.api.Test;
+
+import java.util.Currency;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MoneyTest {
+    @Test
+    void zeroFactoryAllowsZeroAmount() {
+        Money zero = Money.zero(Currency.getInstance("USD"));
+        assertEquals(0, zero.amount().intValue());
+    }
+}

--- a/src/test/java/br/edu/ddd/project/paymentprocessing/domain/model/PaymentTest.java
+++ b/src/test/java/br/edu/ddd/project/paymentprocessing/domain/model/PaymentTest.java
@@ -1,0 +1,31 @@
+package br.edu.ddd.project.paymentprocessing.domain.model;
+
+import br.edu.ddd.project.paymentprocessing.domain.model.entities.Transaction;
+import br.edu.ddd.project.paymentprocessing.domain.model.enums.PaymentMethod;
+import br.edu.ddd.project.paymentprocessing.domain.model.enums.PaymentStatus;
+import br.edu.ddd.project.paymentprocessing.domain.model.valueobjects.*;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaymentTest {
+    @Test
+    void lifecycleProcessingToComplete() {
+        Money amount = Money.of(BigDecimal.TEN, Currency.getInstance("USD"));
+        Payment payment = Payment.create(
+                new OrderId(UUID.randomUUID()),
+                amount,
+                PaymentMethod.CREDIT_CARD,
+                new PaymentDetails("1234123412341234", "Tester", "12/30", "123")
+        );
+        payment.startProcessing();
+        assertEquals(PaymentStatus.PROCESSING, payment.getStatus());
+        payment.complete("ext-id");
+        assertEquals(PaymentStatus.COMPLETED, payment.getStatus());
+        assertTrue(payment.isSuccessful());
+    }
+}

--- a/src/test/java/br/edu/ddd/project/productcatalog/domain/model/agregateRoots/ProductTest.java
+++ b/src/test/java/br/edu/ddd/project/productcatalog/domain/model/agregateRoots/ProductTest.java
@@ -1,0 +1,25 @@
+package br.edu.ddd.project.productcatalog.domain.model.agregateRoots;
+
+import br.edu.ddd.project.productcatalog.domain.model.valueobjects.*;
+import br.edu.ddd.project.ordermanagement.domain.model.valueobject.Money;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProductTest {
+    @Test
+    void stockUpdatesAvailability() {
+        Product product = Product.create(
+                new ProductDescription("Test", "short", "full"),
+                Money.of(BigDecimal.ONE, Currency.getInstance("USD")),
+                CategoryId.generate(),
+                new Stock(1)
+        );
+        assertTrue(product.isAvailable());
+        product.reduceStock(1);
+        assertFalse(product.isAvailable());
+    }
+}

--- a/src/test/java/br/edu/ddd/project/usermanagement/application/usecase/CreateUserUseCaseTest.java
+++ b/src/test/java/br/edu/ddd/project/usermanagement/application/usecase/CreateUserUseCaseTest.java
@@ -1,0 +1,65 @@
+package br.edu.ddd.project.usermanagement.application.usecase;
+
+import br.edu.ddd.project.usermanagement.application.dto.request.CreateUserRequest;
+import br.edu.ddd.project.usermanagement.application.dto.response.UserResponse;
+import br.edu.ddd.project.usermanagement.application.exception.UserAlreadyExistsException;
+import br.edu.ddd.project.usermanagement.application.port.UserRepository;
+import br.edu.ddd.project.usermanagement.application.service.DomainEventPublisher;
+import br.edu.ddd.project.usermanagement.domain.model.agregateRoots.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateUserUseCaseTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private DomainEventPublisher eventPublisher;
+    @InjectMocks
+    private CreateUserUseCase useCase;
+
+    @Test
+    void createsUserAndPublishesEvent() {
+        CreateUserRequest request = new CreateUserRequest(
+                "test@example.com",
+                "pass",
+                "John",
+                "Doe",
+                null,
+                null,
+                Set.of("USER")
+        );
+        when(userRepository.existsByEmail(any())).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
+
+        UserResponse response = useCase.execute(request);
+
+        assertEquals("test@example.com", response.email());
+        verify(eventPublisher).publish(any(UserCreatedEvent.class));
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void throwsWhenEmailExists() {
+        CreateUserRequest request = new CreateUserRequest(
+                "test@example.com",
+                "pass",
+                "John",
+                "Doe",
+                null,
+                null,
+                Set.of("USER")
+        );
+        when(userRepository.existsByEmail(any())).thenReturn(true);
+        assertThrows(UserAlreadyExistsException.class, () -> useCase.execute(request));
+    }
+}


### PR DESCRIPTION
## Summary
- fix validation in `Money` to allow zero amounts
- document project commands with fenced code blocks
- define `DomainEventPublisher` and related event/exception classes
- add unit tests for product catalog, order management, payment, and user management

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_684387b9293c832ab90a3420bbab16ab