### PR TITLE
Add tests for product catalog value objects

### DIFF
--- a/src/test/java/br/edu/ddd/project/productcatalog/domain/model/aggregateRoots/ProductTest.java
+++ b/src/test/java/br/edu/ddd/project/productcatalog/domain/model/aggregateRoots/ProductTest.java
@@ -1,0 +1,90 @@
+package br.edu.ddd.project.productcatalog.domain.model.aggregateRoots;
+
+import br.edu.ddd.project.ordermanagement.domain.model.valueobject.Money;
+import br.edu.ddd.project.productcatalog.domain.model.enums.ProductStatus;
+import br.edu.ddd.project.productcatalog.domain.model.valueobjects.CategoryId;
+import br.edu.ddd.project.productcatalog.domain.model.valueobjects.ProductDescription;
+import br.edu.ddd.project.productcatalog.domain.model.valueobjects.Stock;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Currency;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProductTest {
+
+    private Product createSampleProduct() {
+        ProductDescription description = new ProductDescription("Test", "short", "full");
+        Money price = Money.of(BigDecimal.TEN, Currency.getInstance("USD"));
+        CategoryId categoryId = CategoryId.generate();
+        return Product.create(description, price, categoryId, new Stock(5));
+    }
+
+    @Test
+    void createShouldInitializeProduct() {
+        ProductDescription description = new ProductDescription("Prod", "short", "full");
+        Money price = Money.of(new BigDecimal("20.00"), Currency.getInstance("USD"));
+        CategoryId categoryId = CategoryId.generate();
+        Stock stock = new Stock(3);
+
+        Product product = Product.create(description, price, categoryId, stock);
+
+        assertNotNull(product.getId());
+        assertEquals(description, product.getDescription());
+        assertEquals(price, product.getPrice());
+        assertEquals(categoryId, product.getCategoryId());
+        assertEquals(stock, product.getStock());
+        assertEquals(ProductStatus.ACTIVE, product.getStatus());
+        assertTrue(product.getAttributes().isEmpty());
+        assertNotNull(product.getCreatedAt());
+        assertNotNull(product.getUpdatedAt());
+    }
+
+    @Test
+    void updatePriceShouldChangePriceAndTimestamp() {
+        Product product = createSampleProduct();
+        LocalDateTime previousUpdate = product.getUpdatedAt();
+        Money newPrice = Money.of(new BigDecimal("30.00"), Currency.getInstance("USD"));
+
+        product.updatePrice(newPrice);
+
+        assertEquals(newPrice, product.getPrice());
+        assertTrue(product.getUpdatedAt().isAfter(previousUpdate));
+    }
+
+    @Test
+    void updateStockShouldChangeStatusBasedOnAvailability() {
+        Product product = createSampleProduct();
+
+        product.updateStock(new Stock(0));
+        assertEquals(ProductStatus.OUT_OF_STOCK, product.getStatus());
+        assertEquals(0, product.getStock().quantity());
+
+        product.updateStock(new Stock(2));
+        assertEquals(ProductStatus.ACTIVE, product.getStatus());
+        assertEquals(2, product.getStock().quantity());
+    }
+
+    @Test
+    void addAndReduceStockShouldUpdateQuantityAndStatus() {
+        Product product = createSampleProduct();
+
+        product.reduceStock(5);
+        assertEquals(0, product.getStock().quantity());
+        assertEquals(ProductStatus.OUT_OF_STOCK, product.getStatus());
+
+        product.addStock(3);
+        assertEquals(3, product.getStock().quantity());
+        assertEquals(ProductStatus.ACTIVE, product.getStatus());
+    }
+
+    @Test
+    void addAttributeShouldStoreKeyValue() {
+        Product product = createSampleProduct();
+        product.addAttribute("color", "blue");
+
+        assertEquals("blue", product.getAttributes().get("color"));
+    }
+}

--- a/src/test/java/br/edu/ddd/project/productcatalog/domain/model/valueobjects/CategoryIdTest.java
+++ b/src/test/java/br/edu/ddd/project/productcatalog/domain/model/valueobjects/CategoryIdTest.java
@@ -1,0 +1,31 @@
+package br.edu.ddd.project.productcatalog.domain.model.valueobjects;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CategoryIdTest {
+
+    @Test
+    void constructorShouldRequireNonNullValue() {
+        assertThrows(NullPointerException.class, () -> new CategoryId(null));
+    }
+
+    @Test
+    void generateShouldCreateUniqueIds() {
+        CategoryId id1 = CategoryId.generate();
+        CategoryId id2 = CategoryId.generate();
+        assertNotNull(id1.value());
+        assertNotNull(id2.value());
+        assertNotEquals(id1, id2);
+    }
+
+    @Test
+    void valueShouldReturnProvidedUuid() {
+        UUID uuid = UUID.randomUUID();
+        CategoryId id = new CategoryId(uuid);
+        assertEquals(uuid, id.value());
+    }
+}

--- a/src/test/java/br/edu/ddd/project/productcatalog/domain/model/valueobjects/ProductDescriptionTest.java
+++ b/src/test/java/br/edu/ddd/project/productcatalog/domain/model/valueobjects/ProductDescriptionTest.java
@@ -1,0 +1,26 @@
+package br.edu.ddd.project.productcatalog.domain.model.valueobjects;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProductDescriptionTest {
+
+    @Test
+    void constructorShouldRequireNonNullName() {
+        assertThrows(NullPointerException.class, () -> new ProductDescription(null, "short", "full"));
+    }
+
+    @Test
+    void constructorShouldRejectEmptyName() {
+        assertThrows(IllegalArgumentException.class, () -> new ProductDescription("   ", "short", "full"));
+    }
+
+    @Test
+    void validDescriptionShouldStoreAllValues() {
+        ProductDescription desc = new ProductDescription("Name", "short", "full");
+        assertEquals("Name", desc.name());
+        assertEquals("short", desc.shortDescription());
+        assertEquals("full", desc.fullDescription());
+    }
+}

--- a/src/test/java/br/edu/ddd/project/productcatalog/domain/model/valueobjects/ProductIdTest.java
+++ b/src/test/java/br/edu/ddd/project/productcatalog/domain/model/valueobjects/ProductIdTest.java
@@ -1,0 +1,31 @@
+package br.edu.ddd.project.productcatalog.domain.model.valueobjects;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProductIdTest {
+
+    @Test
+    void constructorShouldRequireNonNullValue() {
+        assertThrows(NullPointerException.class, () -> new ProductId(null));
+    }
+
+    @Test
+    void generateShouldProduceUniqueIds() {
+        ProductId id1 = ProductId.generate();
+        ProductId id2 = ProductId.generate();
+        assertNotNull(id1.value());
+        assertNotNull(id2.value());
+        assertNotEquals(id1, id2);
+    }
+
+    @Test
+    void valueShouldReturnProvidedUuid() {
+        UUID uuid = UUID.randomUUID();
+        ProductId id = new ProductId(uuid);
+        assertEquals(uuid, id.value());
+    }
+}

--- a/src/test/java/br/edu/ddd/project/productcatalog/domain/model/valueobjects/StockTest.java
+++ b/src/test/java/br/edu/ddd/project/productcatalog/domain/model/valueobjects/StockTest.java
@@ -1,0 +1,47 @@
+package br.edu.ddd.project.productcatalog.domain.model.valueobjects;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StockTest {
+
+    @Test
+    void constructorShouldRejectNegativeQuantity() {
+        assertThrows(IllegalArgumentException.class, () -> new Stock(-1));
+    }
+
+    @Test
+    void emptyShouldReturnZeroAndNotAvailable() {
+        Stock stock = Stock.empty();
+        assertEquals(0, stock.quantity());
+        assertFalse(stock.isAvailable());
+    }
+
+    @Test
+    void reduceShouldDecreaseQuantity() {
+        Stock original = new Stock(5);
+        Stock reduced = original.reduce(3);
+        assertEquals(2, reduced.quantity());
+        assertEquals(5, original.quantity());
+    }
+
+    @Test
+    void reduceShouldNotAllowMoreThanAvailable() {
+        Stock original = new Stock(2);
+        assertThrows(IllegalArgumentException.class, () -> original.reduce(3));
+    }
+
+    @Test
+    void increaseShouldReturnStockWithAddedQuantity() {
+        Stock original = new Stock(2);
+        Stock increased = original.increase(3);
+        assertEquals(5, increased.quantity());
+    }
+
+    @Test
+    void isAvailableShouldReflectQuantity() {
+        assertFalse(new Stock(0).isAvailable());
+        assertTrue(new Stock(1).isAvailable());
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit tests covering CategoryId, ProductDescription, ProductId and Stock value objects

## Testing
- `./mvnw -q test` *(fails: wget Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_6843c045da10832aa7f220a401a61b24